### PR TITLE
New API uses variable name as record label.

### DIFF
--- a/examples/App.purs
+++ b/examples/App.purs
@@ -2,7 +2,7 @@ module Example.App where
 
 import Prelude
 
-import Control.Monad.Reader (ReaderT, asks, runReaderT)
+import Control.Monad.Reader (ReaderT, ask, asks, runReaderT)
 import Control.Monad.Reader.Class (class MonadAsk)
 import Data.Either (Either(..))
 import Effect (Effect)
@@ -11,19 +11,17 @@ import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Equality (class TypeEquals, from)
 import Type.Proxy (Proxy(..))
-import TypedEnv (Resolved, Variable, envErrorMessage)
+import TypedEnv (envErrorMessage)
 import TypedEnv (fromEnv) as TypedEnv
 
-type Config f =
-  ( alertEmail :: f "ALERT_EMAIL" String
-  , alertSubject :: f "ALERT_SUBJECT" String
+type Config =
+  ( "ALERT_EMAIL" :: String
+  , "ALERT_SUBJECT" :: String
   )
 
-type ResolvedConfig = Record (Config Resolved)
+newtype AppM a = AppM (ReaderT { | Config } Effect a)
 
-newtype AppM a = AppM (ReaderT ResolvedConfig Effect a)
-
-runAppM :: ResolvedConfig -> AppM ~> Effect
+runAppM :: { | Config } -> AppM ~> Effect
 runAppM env (AppM m) = runReaderT m env
 
 derive newtype instance functorAppM :: Functor AppM
@@ -33,12 +31,12 @@ derive newtype instance bindAppM :: Bind AppM
 derive newtype instance monadAppM :: Monad AppM
 derive newtype instance monadEffectAppM :: MonadEffect AppM
 
-instance monadAskAppM :: TypeEquals e ResolvedConfig => MonadAsk e AppM where
+instance monadAskAppM :: TypeEquals e { | Config } => MonadAsk e AppM where
   ask = AppM $ asks from
 
 main :: Effect Unit
 main = do
-  eitherConfig <- TypedEnv.fromEnv (Proxy :: Proxy (Config Variable)) <$> getEnv
+  eitherConfig <- TypedEnv.fromEnv (Proxy :: _ Config) <$> getEnv
   case eitherConfig of
     Left error ->
       log $ "ERROR: " <> envErrorMessage error
@@ -47,8 +45,7 @@ main = do
 
 sendAlert :: AppM Unit
 sendAlert = do
-  email <- asks _.alertEmail
-  subject <- asks _.alertSubject
+  { "ALERT_EMAIL": email, "ALERT_SUBJECT": subject } <- ask
   liftEffect $ log
     ( "Sending alert with subject \"" <> subject <> "\" to \"" <> email <>
         "\"...done."

--- a/examples/Basic.purs
+++ b/examples/Basic.purs
@@ -8,12 +8,12 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (type (<:), envErrorMessage)
+import TypedEnv (envErrorMessage)
 import TypedEnv (fromEnv) as TypedEnv
 
 type Environment =
-  ( greeting :: String <: "GREETING"
-  , count :: Int <: "COUNT"
+  ( "GREETING" :: String
+  , "COUNT" :: Int
   )
 
 main :: Effect Unit
@@ -22,6 +22,6 @@ main = do
   case env of
     Left error ->
       log $ "ERROR: " <> envErrorMessage error
-    Right { greeting, count } -> do
+    Right { "GREETING": greeting, "COUNT": count } -> do
       _ <- replicateM count (log greeting)
       pure unit

--- a/examples/CustomType.purs
+++ b/examples/CustomType.purs
@@ -9,7 +9,7 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (class ParseValue, type (<:), envErrorMessage)
+import TypedEnv (class ParseValue, envErrorMessage)
 import TypedEnv (fromEnv) as TypedEnv
 
 newtype Port = Port Int
@@ -21,8 +21,8 @@ instance parseValuePort :: ParseValue Port where
   parseValue = map Port <<< find (_ <= 65535) <<< Int.fromString
 
 type Settings =
-  ( host :: String <: "HOST"
-  , port :: Port <: "PORT"
+  ( "HOST" :: String
+  , "PORT" :: Port
   )
 
 main :: Effect Unit
@@ -31,6 +31,6 @@ main = do
   case env of
     Left error ->
       log $ "ERROR: " <> envErrorMessage error
-    Right { host, port } -> do
+    Right { "HOST": host, "PORT": port } -> do
       log $ "Connected to " <> host <> ":" <> show port
       pure unit

--- a/examples/Optional.purs
+++ b/examples/Optional.purs
@@ -8,10 +8,10 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (type (<:), envErrorMessage)
+import TypedEnv (envErrorMessage)
 import TypedEnv (fromEnv) as TypedEnv
 
-type Settings = (username :: Maybe String <: "USERNAME")
+type Settings = ("USERNAME" :: Maybe String)
 
 main :: Effect Unit
 main = do
@@ -19,6 +19,6 @@ main = do
   case env of
     Left error ->
       log $ "ERROR: " <> envErrorMessage error
-    Right { username } -> do
+    Right { "USERNAME": username } -> do
       log $ "Hello, " <> fromMaybe "Sailor" username <> "!"
       pure unit

--- a/examples/Reader.purs
+++ b/examples/Reader.purs
@@ -10,12 +10,12 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (type (<:), envErrorMessage)
+import TypedEnv (envErrorMessage)
 import TypedEnv (fromEnv) as TypedEnv
 
 type Config =
-  ( username :: Maybe String <: "USERNAME"
-  , repeat :: Maybe Int <: "REPEAT"
+  ( "USERNAME" :: Maybe String
+  , "REPEAT" :: Maybe Int
   )
 
 main :: Effect Unit
@@ -24,11 +24,11 @@ main = do
   case env of
     Left error ->
       log $ "ERROR: " <> envErrorMessage error
-    Right config@{ repeat } -> do
+    Right config@{ "REPEAT": repeat } -> do
       _ <- replicateM (1 + fromMaybe 0 repeat) $ log $ runReader greeting config
       pure unit
 
-greeting :: forall r. Reader { username :: Maybe String | r } String
-greeting = asks _.username >>= \username -> pure $ "Hello, "
+greeting :: forall r. Reader { "USERNAME" :: Maybe String | r } String
+greeting = asks _."USERNAME" >>= \username -> pure $ "Hello, "
   <> fromMaybe "Sailor" username
   <> "!"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -13,7 +13,7 @@ import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (runSpec)
 import Type.Proxy (Proxy(..))
-import TypedEnv (type (<:), EnvError(..), fromEnv)
+import TypedEnv (EnvError(..), fromEnv)
 
 main :: Effect Unit
 main = launchAff_ $ runSpec [ consoleReporter ] $
@@ -23,8 +23,8 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
       let
         env = FO.fromHomogeneous
           { "A": "a value", "B": "b value", "C": "c value" }
-        expected = Right { b: "b value", c: "c value" }
-        actual = fromEnv (Proxy :: _ (b :: String <: "B", c :: String <: "C"))
+        expected = Right { "B": "b value", "C": "c value" }
+        actual = fromEnv (Proxy :: _ ("B" :: String, "C" :: String))
           env
       actual `shouldEqual` expected
 
@@ -32,24 +32,24 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
       let
         env = FO.fromHomogeneous { "GREETING": "Hello" }
         expected = Left (EnvLookupError "MESSAGE")
-        actual = fromEnv (Proxy :: _ (message :: String <: "MESSAGE")) env
+        actual = fromEnv (Proxy :: _ ("MESSAGE" :: String)) env
       actual `shouldEqual` expected
 
     it "indicates when parsing a value has failed" do
       let
         env = FO.fromHomogeneous { "DEBUG": "50" }
         expected = Left (EnvParseError "DEBUG")
-        actual = fromEnv (Proxy :: _ (debug :: Boolean <: "DEBUG")) env
+        actual = fromEnv (Proxy :: _ ("DEBUG" :: Boolean)) env
       actual `shouldEqual` expected
 
     it "parses boolean values" do
       traverse_
         ( \({ given, expected }) ->
             shouldEqual
-              ( fromEnv (Proxy :: _ (actual :: Boolean <: "A"))
+              ( fromEnv (Proxy :: _ ("A" :: Boolean))
                   (FO.fromHomogeneous { "A": given })
               )
-              (Right { actual: expected })
+              (Right { "A": expected })
         )
         [ { given: "0", expected: false }
         , { given: "false", expected: false }
@@ -60,34 +60,34 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
     it "parses integer values" do
       let
         env = FO.fromHomogeneous { "VALUE": "123" }
-        expected = Right { value: 123 }
-        actual = fromEnv (Proxy :: _ (value :: Int <: "VALUE")) env
+        expected = Right { "VALUE": 123 }
+        actual = fromEnv (Proxy :: _ ("VALUE" :: Int)) env
       actual `shouldEqual` expected
 
     it "parses character values" do
       let
         env = FO.fromHomogeneous { "VALUE": "x" }
-        expected = Right { value: 'x' }
-        actual = fromEnv (Proxy :: _ (value :: Char <: "VALUE")) env
+        expected = Right { "VALUE": 'x' }
+        actual = fromEnv (Proxy :: _ ("VALUE" :: Char)) env
       actual `shouldEqual` expected
 
     it "parses number values" do
       let
         env = FO.fromHomogeneous { "VALUE": "123.456" }
-        expected = Right { value: 123.456 }
-        actual = fromEnv (Proxy :: _ (value :: Number <: "VALUE")) env
+        expected = Right { "VALUE": 123.456 }
+        actual = fromEnv (Proxy :: _ ("VALUE" :: Number)) env
       actual `shouldEqual` expected
 
     it "parses optional values" do
       let
         env = FO.fromHomogeneous { "VALUE": "Hello" }
-        expected = Right { value: Just "Hello" }
-        actual = fromEnv (Proxy :: _ (value :: Maybe String <: "VALUE")) env
+        expected = Right { "VALUE": Just "Hello" }
+        actual = fromEnv (Proxy :: _ ("VALUE" :: Maybe String)) env
       actual `shouldEqual` expected
 
     it "allows optional values to be absent" do
       let
-        expected = Right { value: Nothing }
-        actual = fromEnv (Proxy :: _ (value :: Maybe String <: "VALUE"))
+        expected = Right { "VALUE": Nothing }
+        actual = fromEnv (Proxy :: _ ("VALUE" :: Maybe String))
           FO.empty
       actual `shouldEqual` expected


### PR DESCRIPTION
Since originally publishing this library, I came to learn that row labels in PureScript don't have to be camel-case. Considering this, there isn't much point in this library attempting to map environment variable names. Instead, we might as well just use the environment variable name as the label, and allow the client code to map to camel-case if needed, hence this PR.

This is a breaking change, of course, but at least client code is simplified...

**Before**

```purescript
TypedEnv.fromEnv (Proxy :: _ (foo :: String <: "FOO"))
```

**After**

```purescript
TypedEnv.fromEnv (Proxy :: _ ("FOO" :: String))
```

**Before**

```purescript
case TypedEnv.fromEnv (Proxy :: _ (foo :: String <: "FOO")) of
  Left err ->
    -- ...
  Right { foo } ->
    -- ....
```

**After**

```purescript
case TypedEnv.fromEnv (Proxy :: _ ("FOO" :: String)) of
  Left err ->
    -- ...
  Right { "FOO": foo } ->
    -- ....
```