### PR TITLE
Accumulate errors in a list instead of extending EnvError type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The [`purescript-node-process` environment API](https://pursuit.purescript.org/p
 provides environment variables in the form of an
 [`Object String`](https://pursuit.purescript.org/packages/purescript-foreign-object/2.0.2/docs/Foreign.Object#t:Object)
 (a string map), but it is left up to us to validate and to parse the values into some configuration model that can be used
-throughout the rest of the program.
+safely throughout the rest of the program.
 
 One of the more popular solutions would be something like this applicative-style lookup/validation/parsing into a record:
 
@@ -31,8 +31,8 @@ However, this is a bit unsatisfying because the explicit lookups, parsing logic,
 verbose and might start to look like a lot of boilerplate as the `Config` model is extended with additional fields.
 The value-level logic creates additional touchpoints when fields are added or removed, or their types change.
 
-Instead, this library uses a type-directed approach, starting with renaming the `Config` fields according to the
-environment variable names from which they are sourced:
+Instead, this library uses a type-directed approach, which starts with renaming the `Config` fields according to the
+environment variable names from which their values are sourced:
 
 ```purescript
 type Config =
@@ -48,10 +48,14 @@ lookups, parsing, or error handling:
 readConfig :: Object String -> Either String Config
 readConfig env =
   bimap
-    envErrorMessage
+    printEnvError
     (\r -> { greeting: r."GREETING", count: r."COUNT" })
     $ TypedEnv.fromEnv (Proxy :: _ Config) env
 ```
+
+> **Note**
+> An additional benefit not demonstrated here is that the `TypedEnv.fromEnv` function accumulates a list of
+> errors, whereas the former example can only present one error at a time.
 
 For more, see the [examples](#examples) section below.
 

--- a/examples/App.purs
+++ b/examples/App.purs
@@ -11,7 +11,7 @@ import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Equality (class TypeEquals, from)
 import Type.Proxy (Proxy(..))
-import TypedEnv (envErrorMessage)
+import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
 
 type Config =
@@ -39,7 +39,7 @@ main = do
   eitherConfig <- TypedEnv.fromEnv (Proxy :: _ Config) <$> getEnv
   case eitherConfig of
     Left error ->
-      log $ "ERROR: " <> envErrorMessage error
+      log $ "ERROR: " <> printEnvError error
     Right config ->
       runAppM config sendAlert
 

--- a/examples/App.purs
+++ b/examples/App.purs
@@ -11,8 +11,8 @@ import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Equality (class TypeEquals, from)
 import Type.Proxy (Proxy(..))
-import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
+import TypedEnv (printEnvError)
 
 type Config =
   ( "ALERT_EMAIL" :: String

--- a/examples/Basic.purs
+++ b/examples/Basic.purs
@@ -8,8 +8,8 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
+import TypedEnv (printEnvError)
 
 type Environment =
   ( "GREETING" :: String

--- a/examples/Basic.purs
+++ b/examples/Basic.purs
@@ -8,7 +8,7 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (envErrorMessage)
+import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
 
 type Environment =
@@ -21,7 +21,7 @@ main = do
   env <- TypedEnv.fromEnv (Proxy :: Proxy Environment) <$> getEnv
   case env of
     Left error ->
-      log $ "ERROR: " <> envErrorMessage error
+      log $ "ERROR: " <> printEnvError error
     Right { "GREETING": greeting, "COUNT": count } -> do
       _ <- replicateM count (log greeting)
       pure unit

--- a/examples/CustomType.purs
+++ b/examples/CustomType.purs
@@ -9,7 +9,7 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (class ParseValue, envErrorMessage)
+import TypedEnv (class ParseValue, printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
 
 newtype Port = Port Int
@@ -30,7 +30,7 @@ main = do
   env <- TypedEnv.fromEnv (Proxy :: Proxy Settings) <$> getEnv
   case env of
     Left error ->
-      log $ "ERROR: " <> envErrorMessage error
+      log $ "ERROR: " <> printEnvError error
     Right { "HOST": host, "PORT": port } -> do
       log $ "Connected to " <> host <> ":" <> show port
       pure unit

--- a/examples/Optional.purs
+++ b/examples/Optional.purs
@@ -8,8 +8,8 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
+import TypedEnv (printEnvError)
 
 type Settings = ("USERNAME" :: Maybe String)
 

--- a/examples/Optional.purs
+++ b/examples/Optional.purs
@@ -8,7 +8,7 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (envErrorMessage)
+import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
 
 type Settings = ("USERNAME" :: Maybe String)
@@ -18,7 +18,7 @@ main = do
   env <- TypedEnv.fromEnv (Proxy :: Proxy Settings) <$> getEnv
   case env of
     Left error ->
-      log $ "ERROR: " <> envErrorMessage error
+      log $ "ERROR: " <> printEnvError error
     Right { "USERNAME": username } -> do
       log $ "Hello, " <> fromMaybe "Sailor" username <> "!"
       pure unit

--- a/examples/Reader.purs
+++ b/examples/Reader.purs
@@ -10,7 +10,7 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (envErrorMessage)
+import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
 
 type Config =
@@ -23,7 +23,7 @@ main = do
   env <- TypedEnv.fromEnv (Proxy :: Proxy Config) <$> getEnv
   case env of
     Left error ->
-      log $ "ERROR: " <> envErrorMessage error
+      log $ "ERROR: " <> printEnvError error
     Right config@{ "REPEAT": repeat } -> do
       _ <- replicateM (1 + fromMaybe 0 repeat) $ log $ runReader greeting config
       pure unit

--- a/examples/Reader.purs
+++ b/examples/Reader.purs
@@ -10,8 +10,8 @@ import Effect (Effect)
 import Effect.Console (log)
 import Node.Process (getEnv)
 import Type.Proxy (Proxy(..))
-import TypedEnv (printEnvError)
 import TypedEnv (fromEnv) as TypedEnv
+import TypedEnv (printEnvError)
 
 type Config =
   ( "USERNAME" :: Maybe String

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,9 +2,11 @@
 , license = "MIT"
 , repository = "https://github.com/nsaunders/purescript-typedenv"
 , dependencies =
-  [ "either"
+  [ "bifunctors"
+  , "either"
   , "foreign-object"
   , "integers"
+  , "lists"
   , "maybe"
   , "numbers"
   , "prelude"

--- a/src/TypedEnv.purs
+++ b/src/TypedEnv.purs
@@ -20,7 +20,7 @@ import Data.Bifunctor (lmap)
 import Data.Either (Either(..), note)
 import Data.Generic.Rep (class Generic)
 import Data.Int (fromString) as Int
-import Data.List (List(..), (:), foldMap)
+import Data.List (List(..), foldMap, (:))
 import Data.Maybe (Maybe(..))
 import Data.Number (fromString) as Number
 import Data.Show.Generic (genericShow)
@@ -65,10 +65,10 @@ printEnvError =
     xxs ->
       "Multiple environment errors: " <> foldMap (\x -> "\n* " <> msg x) xxs
   where
-    msg (EnvLookupError var) =
-      "The required variable \"" <> var <> "\" was not specified."
-    msg (EnvParseError var) =
-      "The variable \"" <> var <> "\" was formatted incorrectly."
+  msg (EnvLookupError var) =
+    "The required variable \"" <> var <> "\" was not specified."
+  msg (EnvParseError var) =
+    "The variable \"" <> var <> "\" was formatted incorrectly."
 
 -- | Parses a `String` value to the specified type.
 class ParseValue ty where
@@ -114,7 +114,10 @@ else instance readValueRequired :: ParseValue a => ReadValue a where
 -- | Transforms a row of environment variable specifications to a record.
 class ReadEnv (e :: Row Type) (r :: Row Type) where
   readEnv
-    :: forall proxy. proxy e -> Object String -> Either (List EnvError) (Record r)
+    :: forall proxy
+     . proxy e
+    -> Object String
+    -> Either (List EnvError) (Record r)
 
 instance readEnvImpl ::
   ( RowToList e el

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Prelude
 
 import Data.Either (Either(..))
+import Data.List (List(Nil), (:))
 import Data.Maybe (Maybe(..))
 import Data.Traversable (traverse_)
 import Effect (Effect)
@@ -31,21 +32,21 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
     it "indicates when a lookup has failed" do
       let
         env = FO.fromHomogeneous { "GREETING": "Hello" }
-        expected = Left (EnvLookupError "MESSAGE")
+        expected = Left (pure $ EnvLookupError "MESSAGE")
         actual = fromEnv (Proxy :: _ ("MESSAGE" :: String)) env
       actual `shouldEqual` expected
 
     it "indicates when parsing a value has failed" do
       let
         env = FO.fromHomogeneous { "DEBUG": "50" }
-        expected = Left (EnvParseError "DEBUG")
+        expected = Left (pure $ EnvParseError "DEBUG")
         actual = fromEnv (Proxy :: _ ("DEBUG" :: Boolean)) env
       actual `shouldEqual` expected
 
     it "indicates when parsing multiple values has failed" do
       let
         env = FO.fromHomogeneous { "A": "err" }
-        expected = Left (EnvErrors [ EnvParseError "A", EnvLookupError "B" ])
+        expected = Left (EnvParseError "A" : EnvLookupError "B" : Nil)
         actual = fromEnv
           (Proxy :: _ ("A" :: Int, "B" :: String))
           env


### PR DESCRIPTION
Following up on #3 and accounting for @srghma's suggestion, I have removed the `EnvErrors` constructor and essentially reverted to the previous error type. Instead, errors are accumulated in a `List EnvError` value which should perform better. (See [here](https://discourse.purescript.org/t/what-nate-told-me-about-array-building/3191).)