### PR TITLE
Cleanup / Record Builder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,12 +17,12 @@
         "purescript-either": "^v6.1.0",
         "purescript-foreign-object": "^v4.0.0",
         "purescript-integers": "^v6.0.0",
+        "purescript-lists": "^v7.0.0",
         "purescript-maybe": "^v6.0.0",
         "purescript-numbers": "^v9.0.0",
         "purescript-prelude": "^v6.0.0",
         "purescript-record": "^v4.0.0",
         "purescript-strings": "^v6.0.0",
-        "purescript-type-equality": "^v4.0.1",
         "purescript-typelevel-prelude": "^v7.0.0"
     }
 }

--- a/example.dhall
+++ b/example.dhall
@@ -9,5 +9,6 @@ in conf // {
     , "lists"
     , "node-process"
     , "transformers"
+    , "type-equality"
     ]
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,8 +2,7 @@
 , license = "MIT"
 , repository = "https://github.com/nsaunders/purescript-typedenv"
 , dependencies =
-  [ "bifunctors"
-  , "either"
+  [ "either"
   , "foreign-object"
   , "integers"
   , "lists"
@@ -12,7 +11,6 @@
   , "prelude"
   , "record"
   , "strings"
-  , "type-equality"
   , "typelevel-prelude"
   ]
 , packages = ./packages.dhall

--- a/src/TypedEnv.purs
+++ b/src/TypedEnv.purs
@@ -29,7 +29,6 @@ import Prim.Row (class Cons, class Lacks) as Row
 import Prim.RowList (class RowToList, Cons, Nil, RowList)
 import Record.Builder (Builder) as Record
 import Record.Builder as RB
-import Type.Equality (class TypeEquals)
 import Type.Proxy (Proxy(..))
 import Type.RowList (class ListToRow)
 
@@ -142,6 +141,5 @@ instance readEnvCons ::
     insert (Left err) (Left errs) = Left $ err : errs
 
 instance readEnvNil ::
-  TypeEquals {} (Record rout) =>
   ReadEnv Nil rout rout where
   readEnv _ _ _ = pure $ RB.union {}

--- a/src/TypedEnv.purs
+++ b/src/TypedEnv.purs
@@ -37,9 +37,9 @@ import Type.RowList (class ListToRow)
 
 -- | Gets a record of environment variables from a Node environment.
 fromEnv
-  :: forall e r proxy
+  :: forall e r
    . ReadEnv e r
-  => proxy e
+  => Proxy e
   -> Object String
   -> Either (List EnvError) (Record r)
 fromEnv = readEnv
@@ -114,8 +114,7 @@ else instance readValueRequired :: ParseValue a => ReadValue a where
 -- | Transforms a row of environment variable specifications to a record.
 class ReadEnv (e :: Row Type) (r :: Row Type) where
   readEnv
-    :: forall proxy
-     . proxy e
+    :: Proxy e
     -> Object String
     -> Either (List EnvError) (Record r)
 
@@ -127,16 +126,15 @@ instance readEnvImpl ::
   , ListToRow el l
   ) =>
   ReadEnv e r where
-  readEnv _ = readEnvFields (Proxy :: Proxy el) (Proxy :: Proxy rl)
+  readEnv _ = readEnvFields (Proxy :: _ el) (Proxy :: _ rl)
 
 -- | Transforms a list of environment variable specifications to a record.
 class
   ReadEnvFields (el :: RowList Type) (rl :: RowList Type) (r :: Row Type)
   | el -> rl where
   readEnvFields
-    :: forall proxy
-     . proxy el
-    -> proxy rl
+    :: Proxy el
+    -> Proxy rl
     -> Object String
     -> Either (List EnvError) (Record r)
 


### PR DESCRIPTION
1. I removed the redundant `ReadEnv` type class and renamed `ReadEnvFields` to take its place.
2. I switched to using [Record Builder](https://pursuit.purescript.org/packages/purescript-record/3.0.0/docs/Record.Builder) to avoid each parsed variable being inserted into an immutable record.