### PR TITLE
`fromEnv`: accept a record type instead of a row type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ environment variable names from which their values are sourced:
 
 ```purescript
 type Config =
-  ( "GREETING" :: String
+  { "GREETING" :: String
   , "COUNT"    :: Int
-  )
+  }
 ```
 
 The `fromEnv` function can now convert the environment `Object String` to a typed record with no need for explicit

--- a/examples/App.purs
+++ b/examples/App.purs
@@ -15,13 +15,13 @@ import TypedEnv (fromEnv) as TypedEnv
 import TypedEnv (printEnvError)
 
 type Config =
-  ( "ALERT_EMAIL" :: String
+  { "ALERT_EMAIL" :: String
   , "ALERT_SUBJECT" :: String
-  )
+  }
 
-newtype AppM a = AppM (ReaderT { | Config } Effect a)
+newtype AppM a = AppM (ReaderT Config Effect a)
 
-runAppM :: { | Config } -> AppM ~> Effect
+runAppM :: Config -> AppM ~> Effect
 runAppM env (AppM m) = runReaderT m env
 
 derive newtype instance functorAppM :: Functor AppM
@@ -31,7 +31,7 @@ derive newtype instance bindAppM :: Bind AppM
 derive newtype instance monadAppM :: Monad AppM
 derive newtype instance monadEffectAppM :: MonadEffect AppM
 
-instance monadAskAppM :: TypeEquals e { | Config } => MonadAsk e AppM where
+instance monadAskAppM :: TypeEquals e Config => MonadAsk e AppM where
   ask = AppM $ asks from
 
 main :: Effect Unit

--- a/examples/Basic.purs
+++ b/examples/Basic.purs
@@ -12,9 +12,9 @@ import TypedEnv (fromEnv) as TypedEnv
 import TypedEnv (printEnvError)
 
 type Environment =
-  ( "GREETING" :: String
+  { "GREETING" :: String
   , "COUNT" :: Int
-  )
+  }
 
 main :: Effect Unit
 main = do

--- a/examples/CustomType.purs
+++ b/examples/CustomType.purs
@@ -21,9 +21,9 @@ instance parseValuePort :: ParseValue Port where
   parseValue = map Port <<< find (_ <= 65535) <<< Int.fromString
 
 type Settings =
-  ( "HOST" :: String
+  { "HOST" :: String
   , "PORT" :: Port
-  )
+  }
 
 main :: Effect Unit
 main = do

--- a/examples/Optional.purs
+++ b/examples/Optional.purs
@@ -11,7 +11,7 @@ import Type.Proxy (Proxy(..))
 import TypedEnv (fromEnv) as TypedEnv
 import TypedEnv (printEnvError)
 
-type Settings = ("USERNAME" :: Maybe String)
+type Settings = { "USERNAME" :: Maybe String }
 
 main :: Effect Unit
 main = do

--- a/examples/Reader.purs
+++ b/examples/Reader.purs
@@ -14,9 +14,9 @@ import TypedEnv (fromEnv) as TypedEnv
 import TypedEnv (printEnvError)
 
 type Config =
-  ( "USERNAME" :: Maybe String
+  { "USERNAME" :: Maybe String
   , "REPEAT" :: Maybe Int
-  )
+  }
 
 main :: Effect Unit
 main = do

--- a/src/TypedEnv.purs
+++ b/src/TypedEnv.purs
@@ -37,7 +37,7 @@ fromEnv
   :: forall r rl
    . RowToList r rl
   => ReadEnv rl () r
-  => Proxy r
+  => Proxy (Record r)
   -> Object String
   -> Either (List EnvError) (Record r)
 fromEnv _ env = RB.buildFromScratch <$> readEnv (Proxy :: _ rl) (Proxy :: _ ())

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -25,7 +25,7 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
         env = FO.fromHomogeneous
           { "A": "a value", "B": "b value", "C": "c value" }
         expected = Right { "B": "b value", "C": "c value" }
-        actual = fromEnv (Proxy :: _ ("B" :: String, "C" :: String))
+        actual = fromEnv (Proxy :: _ { "B" :: String, "C" :: String })
           env
       actual `shouldEqual` expected
 
@@ -33,14 +33,14 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
       let
         env = FO.fromHomogeneous { "GREETING": "Hello" }
         expected = Left (pure $ EnvLookupError "MESSAGE")
-        actual = fromEnv (Proxy :: _ ("MESSAGE" :: String)) env
+        actual = fromEnv (Proxy :: _ { "MESSAGE" :: String }) env
       actual `shouldEqual` expected
 
     it "indicates when parsing a value has failed" do
       let
         env = FO.fromHomogeneous { "DEBUG": "50" }
         expected = Left (pure $ EnvParseError "DEBUG")
-        actual = fromEnv (Proxy :: _ ("DEBUG" :: Boolean)) env
+        actual = fromEnv (Proxy :: _ { "DEBUG" :: Boolean }) env
       actual `shouldEqual` expected
 
     it "indicates when parsing multiple values has failed" do
@@ -48,7 +48,7 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
         env = FO.fromHomogeneous { "A": "err" }
         expected = Left (EnvParseError "A" : EnvLookupError "B" : Nil)
         actual = fromEnv
-          (Proxy :: _ ("A" :: Int, "B" :: String))
+          (Proxy :: _ { "A" :: Int, "B" :: String })
           env
       actual `shouldEqual` expected
 
@@ -56,7 +56,7 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
       traverse_
         ( \({ given, expected }) ->
             shouldEqual
-              ( fromEnv (Proxy :: _ ("A" :: Boolean))
+              ( fromEnv (Proxy :: _ { "A" :: Boolean })
                   (FO.fromHomogeneous { "A": given })
               )
               (Right { "A": expected })
@@ -71,33 +71,33 @@ main = launchAff_ $ runSpec [ consoleReporter ] $
       let
         env = FO.fromHomogeneous { "VALUE": "123" }
         expected = Right { "VALUE": 123 }
-        actual = fromEnv (Proxy :: _ ("VALUE" :: Int)) env
+        actual = fromEnv (Proxy :: _ { "VALUE" :: Int }) env
       actual `shouldEqual` expected
 
     it "parses character values" do
       let
         env = FO.fromHomogeneous { "VALUE": "x" }
         expected = Right { "VALUE": 'x' }
-        actual = fromEnv (Proxy :: _ ("VALUE" :: Char)) env
+        actual = fromEnv (Proxy :: _ { "VALUE" :: Char }) env
       actual `shouldEqual` expected
 
     it "parses number values" do
       let
         env = FO.fromHomogeneous { "VALUE": "123.456" }
         expected = Right { "VALUE": 123.456 }
-        actual = fromEnv (Proxy :: _ ("VALUE" :: Number)) env
+        actual = fromEnv (Proxy :: _ { "VALUE" :: Number }) env
       actual `shouldEqual` expected
 
     it "parses optional values" do
       let
         env = FO.fromHomogeneous { "VALUE": "Hello" }
         expected = Right { "VALUE": Just "Hello" }
-        actual = fromEnv (Proxy :: _ ("VALUE" :: Maybe String)) env
+        actual = fromEnv (Proxy :: _ { "VALUE" :: Maybe String }) env
       actual `shouldEqual` expected
 
     it "allows optional values to be absent" do
       let
         expected = Right { "VALUE": Nothing }
-        actual = fromEnv (Proxy :: _ ("VALUE" :: Maybe String))
+        actual = fromEnv (Proxy :: _ { "VALUE" :: Maybe String })
           FO.empty
       actual `shouldEqual` expected


### PR DESCRIPTION
With this change, `fromEnv` will accept the desired record type instead of a row type. I'm thinking this should simplify client code most of the time. For example:

**Before**

```purescript
type ConfigRep =
  ( "FOO" :: String
  , "BAR" :: Int
  )

type Config = { | ConfigRep }

config :: Object String -> Either (List EnvError) Config
config = fromEnv (Proxy :: _ ConfigRep)
```

**After**

```purescript
type Config =
  { "FOO" :: String
  , "BAR" :: Int
  }

config :: Object String -> Either (List EnvError) Config
config = fromEnv (Proxy :: _ Config)
```